### PR TITLE
Added imprint link in order to comply to german regulations

### DIFF
--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -428,6 +428,9 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 					$_POST['options']['gdpr']['policy_page_label']   = sanitize_text_field( $_POST['options']['gdpr']['policy_page_label'] );
 					$_POST['options']['gdpr']['policy_page_link']    = esc_url_raw( $_POST['options']['gdpr']['policy_page_link'] );
 					$_POST['options']['gdpr']['policy_page_target']  = (int) $_POST['options']['gdpr']['policy_page_target'];
+					$_POST['options']['gdpr']['imprint_page_label']   = sanitize_text_field( $_POST['options']['gdpr']['imprint_page_label'] );
+					$_POST['options']['gdpr']['imprint_page_link']    = esc_url_raw( $_POST['options']['gdpr']['imprint_page_link'] );
+					$_POST['options']['gdpr']['imprint_page_target']  = (int) $_POST['options']['gdpr']['imprint_page_target'];
 					$_POST['options']['gdpr']['contact_form_tail']   = wp_kses( $_POST['options']['gdpr']['contact_form_tail'], wpmm_gdpr_textarea_allowed_html() );
 					$_POST['options']['gdpr']['subscribe_form_tail'] = wp_kses( $_POST['options']['gdpr']['subscribe_form_tail'], wpmm_gdpr_textarea_allowed_html() );
 

--- a/includes/classes/wp-maintenance-mode.php
+++ b/includes/classes/wp-maintenance-mode.php
@@ -187,6 +187,9 @@ if ( ! class_exists( 'WP_Maintenance_Mode' ) ) {
 					'policy_page_label'   => __( 'Privacy Policy', 'wp-maintenance-mode' ),
 					'policy_page_link'    => '',
 					'policy_page_target'  => 0,
+					'imprint_page_label'  => __( 'Imprint', 'wp-maintenance-mode' ),
+					'imprint_page_link'   => '',
+					'imprint_page_target' => 0,
 					'contact_form_tail'   => __( 'This form collects your name and email so that we can reach you back. Check out our <a href="#">Privacy Policy</a> page to fully understand how we protect and manage your submitted data.', 'wp-maintenance-mode' ),
 					'subscribe_form_tail' => __( 'This form collects your email so that we can add you to our newsletter list. Check out our <a href="#">Privacy Policy</a> page to fully understand how we protect and manage your submitted data.', 'wp-maintenance-mode' ),
 				),
@@ -509,6 +512,30 @@ if ( ! class_exists( 'WP_Maintenance_Mode' ) ) {
 
 			if ( empty( $v2_options['design']['footer_links_color'] ) ) {
 				$v2_options['design']['footer_links_color'] = $default_options['design']['footer_links_color'];
+
+				// update options
+				update_option( 'wpmm_settings', $v2_options );
+			}
+
+			/**
+			 * Update from <= v2.4.7 to 2.4.8
+			 */
+			if ( empty( $v2_options['gdpr']['imprint_page_target'] ) ) {
+				$v2_options['gdpr']['imprint_page_target'] = $default_options['gdpr']['imprint_page_target'];
+
+				// update options
+				update_option( 'wpmm_settings', $v2_options );
+			}
+
+			if ( empty( $v2_options['gdpr']['imprint_page_link'] ) ) {
+				$v2_options['gdpr']['imprint_page_link'] = $default_options['gdpr']['imprint_page_link'];
+
+				// update options
+				update_option( 'wpmm_settings', $v2_options );
+			}
+			
+			if ( empty( $v2_options['gdpr']['imprint_page_label'] ) ) {
+				$v2_options['gdpr']['imprint_page_label'] = $default_options['gdpr']['imprint_page_label'];
 
 				// update options
 				update_option( 'wpmm_settings', $v2_options );
@@ -909,7 +936,7 @@ if ( ! class_exists( 'WP_Maintenance_Mode' ) ) {
 
 			// "Design > Content > Footer links" color
 			if ( ! empty( $this->plugin_settings['design']['footer_links_color'] ) ) {
-				$css_rules['design.footer_links_color'] = sprintf( '.wrap .footer_links a, .wrap .author_link a { color: %s; }', sanitize_hex_color( $this->plugin_settings['design']['footer_links_color'] ) );
+				$css_rules['design.footer_links_color'] = sprintf( '.wrap .footer_links, .wrap .footer_links a, .wrap .author_link a { color: %s; }', sanitize_hex_color( $this->plugin_settings['design']['footer_links_color'] ) );
 			}
 
 			// "Design > Background" color

--- a/views/maintenance.php
+++ b/views/maintenance.php
@@ -235,8 +235,18 @@ defined( 'ABSPATH' ) || exit;
 						<a href="<?php echo esc_url( admin_url() ); ?>"><?php esc_html_e( 'Dashboard', 'wp-maintenance-mode' ); ?></a> 
 					<?php } ?>
 
-					<?php if ( $this->plugin_settings['gdpr']['status'] === 1 ) { ?>
+					<?php if ( $this->plugin_settings['gdpr']['status'] === 1 && 
+					           ! empty( $this->plugin_settings['gdpr']['policy_page_link'] ) ) { ?>
 						<a href="<?php echo esc_url( $this->plugin_settings['gdpr']['policy_page_link'] ); ?>" target="<?php echo ! empty( $this->plugin_settings['gdpr']['policy_page_target'] ) && $this->plugin_settings['gdpr']['policy_page_target'] === 1 ? '_blank' : '_self'; ?>"><?php echo esc_html( $this->plugin_settings['gdpr']['policy_page_label'] ); ?></a>
+					<?php } ?>
+					<?php if ( $this->plugin_settings['gdpr']['status'] === 1 &&
+					           ! empty( $this->plugin_settings['gdpr']['policy_page_link'] ) && 
+							   ! empty( $this->plugin_settings['gdpr']['imprint_page_link'] ) ) { ?>
+						 |
+					<?php } ?>
+					<?php if ( $this->plugin_settings['gdpr']['status'] === 1 && 
+							   ! empty( $this->plugin_settings['gdpr']['imprint_page_link'] ) ) { ?>
+						<a href="<?php echo esc_url( $this->plugin_settings['gdpr']['imprint_page_link'] ); ?>" target="<?php echo ! empty( $this->plugin_settings['gdpr']['imprint_page_target'] ) && $this->plugin_settings['gdpr']['imprint_page_target'] === 1 ? '_blank' : '_self'; ?>"><?php echo esc_html( $this->plugin_settings['gdpr']['imprint_page_label'] ); ?></a>
 					<?php } ?>
 				</div>
 			<?php } ?>

--- a/views/settings.php
+++ b/views/settings.php
@@ -875,6 +875,36 @@ defined( 'ABSPATH' ) || exit;
 								</tr>
 								<tr valign="top">
 									<th scope="row">
+										<label for="options[gdpr][imprint_page_label]"><?php esc_html_e( 'Imprint Link name', 'wp-maintenance-mode' ); ?></label>
+									</th>
+									<td>
+										<input type="text" value="<?php echo esc_attr( $this->plugin_settings['gdpr']['imprint_page_label'] ); ?>" name="options[gdpr][imprint_page_label]" />
+										<p class="description"><?php esc_html_e( 'Label the link that will be shown on frontend footer', 'wp-maintenance-mode' ); ?></p>
+									</td>
+								</tr>
+								<tr valign="top">
+									<th scope="row">
+										<label for="options[gdpr][imprint_page_link]"><?php esc_html_e( 'Imprint page link', 'wp-maintenance-mode' ); ?></label>
+									</th>
+									<td>
+										<input type="text" value="<?php echo esc_url( $this->plugin_settings['gdpr']['imprint_page_link'] ); ?>" name="options[gdpr][imprint_page_link]" />
+										<p class="description"><?php esc_html_e( 'REMEMBER: In order to make the imprint page accessible you need to add it in General -> Exclude.', 'wp-maintenance-mode' ); ?></p>
+									</td>
+								</tr>
+								<tr valign="top">
+									<th scope="row">
+										<label for="options[gdpr][imprint_page_target]"><?php esc_html_e( 'Imprint link target', 'wp-maintenance-mode' ); ?></label>
+									</th>
+									<td>
+										<select name="options[gdpr][imprint_page_target]">
+											<option value="1"<?php selected( $this->plugin_settings['gdpr']['imprint_page_target'], 1 ); ?>><?php esc_html_e( 'New page', 'wp-maintenance-mode' ); ?></option>
+											<option value="0"<?php selected( $this->plugin_settings['gdpr']['imprint_page_target'], 0 ); ?>><?php esc_html_e( 'Same page', 'wp-maintenance-mode' ); ?></option>
+										</select>
+										<p class="description"><?php esc_html_e( 'Choose how the link will open.', 'wp-maintenance-mode' ); ?></p>
+									</td>
+								</tr>
+								<tr valign="top">
+									<th scope="row">
 										<label for="options[gdpr][contact_form_tail]"><?php esc_html_e( 'Contact form \'tail\'', 'wp-maintenance-mode' ); ?></label>
 									</th>
 									<td>


### PR DESCRIPTION
In germany it's necessary to have an imprint which is accessible from every site of your website.

I've added this feature according to the way how the policy page was implemented.
The template also watches if there is an imprint and a privacy policy page is configured and adds a simple "|" as divider.