### PR TITLE
Rebrand notice

### DIFF
--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -903,7 +903,7 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 			$notices = array();
 
 			// show this notice if user had the plugin installed on the moment of rebranding
-			if ( ThemeisleSDK\Product::get( WPMM_PATH )->get_install_time() < strtotime( '2022-11-02' ) ) {
+			if ( ThemeisleSDK\Product::get( WPMM_FILE )->get_install_time() < strtotime( '2022-11-02' ) ) {
 				$notices['rebrand'] = array(
 					'class' => 'notice wpmm_notices notice-success is-dismissible',
 					'msg'   => __( 'WP Maintenance Mode is now LightStart. Enjoy the same features, more templates and new landing pages building compatibility.', 'wp-maintenance-mode' ),

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -902,6 +902,14 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 			$screen  = get_current_screen();
 			$notices = array();
 
+			// show this notice if user had the plugin installed on the moment of rebranding
+			if ( ThemeisleSDK\Product::get( WPMM_PATH )->get_install_time() < strtotime( '2022-11-02' ) ) {
+				$notices['rebrand'] = array(
+					'class' => 'notice wpmm_notices notice-success is-dismissible',
+					'msg'   => __( 'WP Maintenance Mode is now LightStart. Enjoy the same features, more templates and new landing pages building compatibility.', 'wp-maintenance-mode' ),
+				);
+			}
+
 			if ( $this->plugin_screen_hook_suffix !== $screen->id ) {
 				// notice if plugin is activated
 				if (

--- a/wp-maintenance-mode.php
+++ b/wp-maintenance-mode.php
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
  * DEFINE PATHS
  */
 define( 'WPMM_PATH', plugin_dir_path( __FILE__ ) );
+define( 'WPMM_FILE', __FILE__ );
 define( 'WPMM_CLASSES_PATH', WPMM_PATH . 'includes/classes/' );
 define( 'WPMM_FUNCTIONS_PATH', WPMM_PATH . 'includes/functions/' );
 define( 'WPMM_LANGUAGES_PATH', basename( WPMM_PATH ) . '/languages/' );


### PR DESCRIPTION
If the install time of the plugin is earlier than the day of the rebranding, show a dismissible notice to announce the user.