### PR TITLE
chore: update wp tested version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Author URI:** https://themeisle.com/  
 **Tags:** maintenance mode, admin, administration, unavailable, coming soon, multisite, landing page, under construction, contact form, subscribe, countdown  
 **Requires at least:** 3.5  
-**Tested up to:** 6.2  
+**Tested up to:** 6.4  
 **Stable tag:** 2.6.8  
 **Requires PHP:** 5.6  
 **License:** GPL-2.0+  

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Author: Themeisle
 Author URI: https://themeisle.com/
 Tags: maintenance mode, admin, administration, unavailable, coming soon, multisite, landing page, under construction, contact form, subscribe, countdown
 Requires at least: 4.7
-Tested up to: 6.3
+Tested up to: 6.4
 Stable tag: 2.6.8
 Requires PHP: 5.6
 License: GPL-2.0+


### PR DESCRIPTION
Update WP tested version to 6.4 as the only [found issue](https://github.com/Codeinwp/wp-maintenance-mode/issues/407) was fixed