### PR TITLE
Feat/hyve promo

### DIFF
--- a/assets/css/style-admin.css
+++ b/assets/css/style-admin.css
@@ -412,6 +412,29 @@ input[type="button"].button.button-secondary.is-busy {
     height: 1em;
 }
 
+.wpmm-notice {
+    background-color: #fff;
+    border-left: 4px solid #00a0d2;
+    box-shadow: 0 1px 1px rgba(0,0,0,.04);
+    padding: 12px;
+    display: flex;
+    align-items: center;
+}
+
+.wpmm-notice-content {
+    flex-grow: 1;
+}
+
+.wpmm-notice h3 {
+    margin: 0.5em 0;
+    font-size: 14px;
+}
+
+.wpmm-notice p {
+    margin: 0.5em 0;
+    font-size: 13px;
+}
+
 @keyframes spin {
     from {
         transform: rotate(0deg);

--- a/assets/css/style-wizard.css
+++ b/assets/css/style-wizard.css
@@ -79,6 +79,8 @@ h2.wpmm-title span img {
 
     letter-spacing: .04em;
     line-height: 1;
+    --checkbox-input-size: 20px;
+    --checkmark-size: calc(var(--checkbox-input-size) + 4px);
 }
 
 #wpmm-wizard-wrapper .slider-wrap {

--- a/assets/js/scripts-admin.js
+++ b/assets/js/scripts-admin.js
@@ -387,7 +387,7 @@ jQuery( function( $ ) {
 		$( this ).addClass( 'is-busy' );
 		$( this ).trigger( 'blur' );
 
-		handleOptimole().then( function() {
+		handlePlugins().then( function() {
 			$.post( wpmmVars.ajaxURL, {
 				action: 'wpmm_skip_wizard',
 				_wpnonce: wpmmVars.wizardNonce,
@@ -519,7 +519,7 @@ jQuery( function( $ ) {
 	 */
 	function importTemplate( data, callback ) {
 		handleOtter()
-			.then( () => handleOptimole() )
+			.then( () => handlePlugins() )
 			.then( () => addToPage( data, callback ) )
 			.catch( ( error ) => {
 				// eslint-disable-next-line no-console
@@ -575,23 +575,39 @@ jQuery( function( $ ) {
 	}
 
 	/**
-	 * Install and activate Optimole if the checkbox is checked.
+	 * Install and activate recommended plugins if the checkboxes is checked.
 	 */
-	function handleOptimole() {
+	function handlePlugins() {
 		const optimoleCheckbox = $( '#wizard-optimole-checkbox' );
+		const hyveCheckbox = $( '#wizard-hyve-checkbox' );
+
+		let promiseChain = Promise.resolve();
 
 		if ( optimoleCheckbox.length && optimoleCheckbox.is( ':checked' ) ) {
-			if ( ! wpmmVars.isOptimoleInstalled ) {
-				return installPlugin( 'optimole-wp' )
-					.then( () => {
+			promiseChain = promiseChain
+				.then(() => {
+					if ( ! wpmmVars.isOptimoleInstalled ) {
+						return installPlugin( 'optimole-wp' ).then( () => activatePlugin( 'optimole-wp' ) );
+					} else if ( ! wpmmVars.isOptimoleActive ) {
 						return activatePlugin( 'optimole-wp' );
-					} );
-			} else if ( ! wpmmVars.isOptimoleActive ) {
-				return activatePlugin( 'optimole-wp' );
-			}
+					}
+				});
 		}
 
-		return Promise.resolve();
+		if ( hyveCheckbox.length && hyveCheckbox.is( ':checked' ) ) {
+			promiseChain = promiseChain
+				.then(() => {
+					if ( ! wpmmVars.isHyveInstalled ) {
+						return installPlugin( 'hyve-lite' ).then( () => activatePlugin( 'hyve-lite' ) );
+					} else if ( ! wpmmVars.isHyveActive ) {
+						return activatePlugin( 'hyve-lite' );
+					}
+				});
+		}
+
+		return promiseChain.catch( ( error ) => {
+			console.error( 'Error in plugin installation or activation:', error );
+		});
 	}
 
 	/**
@@ -656,6 +672,8 @@ jQuery( function( $ ) {
 				return $.get( wpmmVars.otterActivationLink );
 			case 'optimole-wp':
 				return $.get( wpmmVars.optimoleActivationLink );
+			case 'hyve-lite':
+				return $.get( wpmmVars.hyveActivationLink );
 			default:
 				break;
 		}

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -157,6 +157,8 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 						'isOtterActive'          => is_plugin_active( 'otter-blocks/otter-blocks.php' ),
 						'isOptimoleInstalled'    => file_exists( ABSPATH . 'wp-content/plugins/optimole-wp/optimole-wp.php' ),
 						'isOptimoleActive'       => is_plugin_active( 'optimole-wp/optimole-wp.php' ),
+						'isHyveInstalled'        => file_exists( ABSPATH . 'wp-content/plugins/hyve-lite/hyve-lite.php' ),
+						'isHyveActive'           => is_plugin_active( 'hyve-lite/hyve-lite.php' ),
 						'errorString'            => __( 'Something went wrong, please try again.', 'wp-maintenance-mode' ),
 						'loadingString'          => __( 'Doing some magic...', 'wp-maintenance-mode' ),
 						'importingText'          => __( 'Importing', 'wp-maintenance-mode' ),
@@ -184,6 +186,16 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 								'plugin_status' => 'all',
 								'paged'         => '1',
 								'_wpnonce'      => wp_create_nonce( 'activate-plugin_optimole-wp/optimole-wp.php' ),
+							),
+							esc_url( network_admin_url( 'plugins.php' ) )
+						),
+						'hyveActivationLink'     => add_query_arg(
+							array(
+								'action'        => 'activate',
+								'plugin'        => rawurlencode( 'hyve-lite/hyve-lite.php' ),
+								'plugin_status' => 'all',
+								'paged'         => '1',
+								'_wpnonce'      => wp_create_nonce( 'activate-plugin_hyve-lite/hyve-lite.php' ),
 							),
 							esc_url( network_admin_url( 'plugins.php' ) )
 						),
@@ -1169,7 +1181,7 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 		 * @return string
 		 */
 		public function add_wizard_classes( $classes ) {
-			if ( get_option( 'wpmm_fresh_install', false ) ) {
+			if ( ! get_option( 'wpmm_fresh_install', false ) ) {
 				$classes .= 'wpmm-wizard-fullscreen';
 			}
 

--- a/views/settings.php
+++ b/views/settings.php
@@ -12,7 +12,19 @@ if ( ! isset( $this->plugin_settings['design']['page_id'] ) ) {
 	$this->plugin_settings['design']['page_id'] = 0;
 }
 
-$is_otter_active = is_plugin_active( 'otter-blocks/otter-blocks.php' ) || defined( 'OTTER_BLOCKS_VERSION' );
+$is_otter_active   = is_plugin_active( 'otter-blocks/otter-blocks.php' ) || defined( 'OTTER_BLOCKS_VERSION' );
+$is_hyve_installed = file_exists( ABSPATH . 'wp-content/plugins/hyve-lite/hyve-lite.php' ) || defined( 'HYVE_LITE_VERSION' );
+
+$hyve_url = add_query_arg(
+	array(
+		'tab'       => 'plugin-information',
+		'plugin'    => 'hyve-lite',
+		'TB_iframe' => true,
+		'width'     => 800,
+		'height'    => 800,
+	),
+	network_admin_url( 'plugin-install.php' )
+);
 ?>
 <div class="wrap">
 	<h2 class="wpmm-title"><?php echo esc_html( get_admin_page_title() ); ?>
@@ -818,6 +830,15 @@ $is_otter_active = is_plugin_active( 'otter-blocks/otter-blocks.php' ) || define
 							<tbody>
 								<tr valign="top">
 									<td colspan="2">
+										<?php if ( ! $is_hyve_installed ) : ?>
+											<div class="wpmm-notice">
+												<div class="wpmm-notice-content">
+													<h3><?php esc_html_e( 'Enhance Your WordPress Site with Hyve AI Chatbot', 'wp-maintenance-mode' ); ?></h3>
+													<p><?php esc_html_e( 'Hyve is an AI chatbot plugin for WordPress, ideal for sites in maintenance mode. It enhances user experience by turning your content into interactive conversations, helping visitors access information while your site is under development.', 'wp-maintenance-mode' ); ?></p>
+												</div>
+												<a target="_black" href="<?php echo esc_url( $hyve_url ); ?>" class="button button-primary"><?php esc_html_e( 'Install Hyve', 'wp-maintenance-mode' ); ?></a>
+											</div>
+										<?php endif; ?>
 										<h4><?php esc_html_e( 'Setup the conversation steps to capture more subscribers with this friendly way of asking email addresses.', 'wp-maintenance-mode' ); ?></h4>
 										<p><?php esc_html_e( 'You may also want to use these wildcards: {bot_name} and {visitor_name} to make the conversation even more realistic.', 'wp-maintenance-mode' ); ?></p>
 										<p><?php esc_html_e( 'It is also ok if you don\'t fill in all the conversation steps if you don\'t need to.', 'wp-maintenance-mode' ); ?></p>

--- a/views/wizard.php
+++ b/views/wizard.php
@@ -85,6 +85,32 @@ $default_templates = array(
 							?>
 					</div>
 				<?php } ?>
+
+				<?php if ( ! is_plugin_active( 'hyve-lite/hyve-lite.php' ) || ! defined( 'HYVE_LITE_VERSION' ) ) { ?>
+					<div class="optimole-upsell">
+						<div class="optimole-upsell-container">
+							<span class="components-checkbox-control__input-container">
+								<input id="wizard-hyve-checkbox" type="checkbox" class="components-checkbox-control__input" checked>
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="presentation" class="components-checkbox-control__checked" aria-hidden="true" focusable="false"><path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"></path></svg>
+							</span>
+							<label for="wizard-hyve-checkbox">
+								<?php esc_html_e( 'Interactive Chatbot', 'wp-maintenance-mode' ); ?>
+							</label>
+						</div>
+						<p class="description">
+							<?php
+								printf(
+									wp_kses(
+										/* translators: Hyve Lite url */
+										__( '<a href="%1$s" target="_blank">Hyve%2$s</a> is an AI chatbot plugin for WordPress, ideal for sites in maintenance mode. It enhances user experience by turning your content into interactive conversations, helping visitors access information while your site is under development.', 'wp-maintenance-mode' ),
+										wpmm_translated_string_allowed_html()
+									),
+									esc_url( 'https://wordpress.org/plugins/hyve-lite/' ),
+									$this->get_external_link_icon()
+								);
+							?>
+					</div>
+				<?php } ?>
 				<div id="wizard-buttons" class="import-button">
 					<input type="button" class="button button-big button-primary disabled button-import" value="<?php esc_html_e( 'Continue', 'wp-maintenance-mode' ); ?>"/>
 					<input type="button" class="button button-big button-secondary button-skip" value="<?php esc_html_e( 'I don’t want to use a template', 'wp-maintenance-mode' ); ?>"/>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This PR adds Hyve promo to WPMM's Onboarding Wizard and Chatbot screen. It also fixes an issue I spotted while working that Checkbox on Wizard for installation consent is almost invisible due to some CSS variables not existing.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

<img width="1753" alt="Screenshot 2024-09-17 at 12 36 31 PM" src="https://github.com/user-attachments/assets/f1c16ffc-a492-4b19-bd32-28914a734fc5">
<img width="2560" alt="Screenshot 2024-09-17 at 12 38 30 PM" src="https://github.com/user-attachments/assets/81475395-5491-4ad0-8d21-38c048510007">

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the plugin is installed properly, and the notices only appear if the plugin doesn't exist on your site.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/hyve/issues/19.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
