### PR TITLE
Add a Blueprint for WP.org Live Preview

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,0 +1,15 @@
+{
+  "preferredVersions": {
+    "php": "latest",
+    "wp": "latest"
+  },
+  "features": {
+    "networking": true
+  },
+  "plugins": [
+    "wp-maintenance-mode"
+  ],
+  "login": true,
+  "landingPage": "/wp-admin/admin.php?page=wp-maintenance-mode",
+  "steps": []
+}


### PR DESCRIPTION
### Summary

This PR adds a Blueprint file so that Better Search Replace can have a Live Preview button in the WP.org plugin repo. The Live Preview will load your plugin in the WordPress Playground web app using the provided Blueprint.

According to [the WP.org docs](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/#enabling-plugin-previews):

> There are two things required for a plugin preview button to appear to all users:
> 1. A valid blueprint.json file must be provided in a blueprints sub-directory of the plugin’s assets folder.
> 2. The plugin preview must be set to “public” from the plugin’s Advanced view by a committer.

Once those conditions are met, a Live Preview button should appear next to the Download button in the WordPress.org plugin repo, like:

![image](https://github.com/user-attachments/assets/07d7d338-0faa-4c33-83de-5991ebc081df)

Try [this link](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fbrandonpayton%2Fwp-maintenance-mode%2F6138632e930dfe7d458343dc2c7ebd33f0c27cea%2Fassets%2Fblueprints%2Fblueprint.json) for an example of the preview.

I work on the [WordPress Playground project](https://github.com/WordPress/wordpress-playground) and have started creating some PRs to propose Live Preview for various plugins. If you have any feedback related to Playground or Live Previews, I would love to hear it.

### Will affect visual aspect of the product

NO

### Screenshots <!-- if applicable -->

A screenshot of the Live Preview blueprint running in WordPress Playground:
![Screenshot 2024-12-11 at 5 20 31 PM](https://github.com/user-attachments/assets/ede65867-0ce0-449a-be56-dad7b33b4623)


### Test instructions

This is not a functional change, but you can try [this link](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fbrandonpayton%2Fwp-maintenance-mode%2F6138632e930dfe7d458343dc2c7ebd33f0c27cea%2Fassets%2Fblueprints%2Fblueprint.json) for an example of the preview.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

