### PR TITLE
Fixed load textdomain issue with WP 6.7

### DIFF
--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -23,12 +23,8 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 		 * 3, 2, 1... Start!
 		 */
 		private function __construct() {
-			$plugin                        = WP_Maintenance_Mode::get_instance();
-			$this->plugin_slug             = $plugin->get_plugin_slug();
-			$this->plugin_settings         = $plugin->get_plugin_settings();
-			$this->plugin_network_settings = $plugin->get_plugin_network_settings();
-			$this->plugin_default_settings = $plugin->default_settings();
-			$this->plugin_basename         = plugin_basename( WPMM_PATH . $this->plugin_slug . '.php' );
+			// Init.
+			add_action( 'init', array( $this, 'load_default_settings' ) );
 
 			// Load admin style sheet and JavaScript.
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
@@ -93,6 +89,18 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 			}
 
 			return self::$instance;
+		}
+
+		/**
+		 * Load default settings.
+		 */
+		public function load_default_settings() {
+			$plugin                        = WP_Maintenance_Mode::get_instance();
+			$this->plugin_slug             = $plugin->get_plugin_slug();
+			$this->plugin_settings         = $plugin->get_plugin_settings();
+			$this->plugin_network_settings = $plugin->get_plugin_network_settings();
+			$this->plugin_basename         = plugin_basename( WPMM_PATH . $this->plugin_slug . '.php' );
+			$this->plugin_default_settings = $plugin->default_settings();
 		}
 
 		/**


### PR DESCRIPTION
### Summary
I have removed the early translation function call following [WordPress standards](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/).

### Will affect visual aspect of the product
Yes

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/wp-maintenance-mode/issues/465
