### PR TITLE
Fixed broken onboarding layout

### DIFF
--- a/assets/css/style-wizard.css
+++ b/assets/css/style-wizard.css
@@ -4,7 +4,8 @@
 .wpmm-wizard-fullscreen .wrap .notice,
 .wpmm-wizard-fullscreen .wrap .error,
 .wpmm-wizard-fullscreen .wrap .updated,
-.wpmm-wizard-fullscreen #wpfooter {
+.wpmm-wizard-fullscreen #wpfooter,
+.wpmm-wizard-fullscreen .rop-revive-network-admin-notice {
     display: none !important;
 }
 
@@ -328,6 +329,7 @@ input.invalid:focus {
 
 .optimole-upsell-container {
     display: flex;
+    gap: 8px;
 }
 
 .optimole-upsell {
@@ -341,7 +343,7 @@ input.invalid:focus {
 }
 
 .optimole-upsell p.description {
-    margin-left: 35px;
+    margin-left: 30px;
     margin-top: 12px;
     font-size: 15px;
     max-width: 980px;

--- a/includes/classes/wp-maintenance-mode-admin.php
+++ b/includes/classes/wp-maintenance-mode-admin.php
@@ -1177,7 +1177,7 @@ if ( ! class_exists( 'WP_Maintenance_Mode_Admin' ) ) {
 		 * @return string
 		 */
 		public function add_wizard_classes( $classes ) {
-			if ( ! get_option( 'wpmm_fresh_install', false ) ) {
+			if ( get_option( 'wpmm_fresh_install', false ) ) {
 				$classes .= ' wpmm-wizard-fullscreen';
 			}
 


### PR DESCRIPTION
### Summary
Fixed broken onboarding layout and adds some minor CSS improvements.

Here:
![LightStart-‹-Marketing-Agency-—-WordPress-01-10-2025_09_43_AM](https://github.com/user-attachments/assets/b190953a-9913-4259-897c-6b9508c3f04e)

### Will affect visual aspect of the product
Yes

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/wp-maintenance-mode/issues/470
